### PR TITLE
feat: support release in github action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,11 +18,11 @@ jobs:
           node-version: 16
           registry-url: https://npm.pkg.github.com/
           scope: "@zalopay-oss"
+      - name: Install dependencies
+        run: npm i
       - name: Compile the package
         run: |
           npm run build
-      - name: Install dependencies
-        run: npm ci
       - name: Publish package to GitHub Packages
         run: npm publish --access public
         env:
@@ -38,7 +38,7 @@ jobs:
           node-version: 16
           registry-url: "https://registry.npmjs.org"
       - name: Install dependencies
-        run: npm ci
+        run: npm i
       - name: Compile the package
         run: |
           npm run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 name: Publish package to GitHub Packages and NPM registry
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "v*.*.*"
 jobs:
   github_packages:
     runs-on: ubuntu-latest
@@ -46,3 +46,15 @@ jobs:
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  release:
+    permissions:
+      contents: write
+    needs: [github-packages, npm-registry]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: GH Release
+        uses: softprops/action-gh-release@v0.1.15
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          generate_release_notes: true


### PR DESCRIPTION
Refactor github action:
- Trigger only when a tag is created
- Support creating a release after publishing to the npm registry and github packages successfully
- Use npm install instead of npm clean install because we removed the package-lock.json