### PR TITLE
fix: create order request example amount field incorrect type

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ const order: CreateOrderRequest = {
   appUser: "user_id",
   item: JSON.stringify(items),
   embedData: JSON.stringify(embed_data),
-  amount: "amount",
+  amount: 1000,
   description: "description",
   bankCode: "zalopayapp",
   type: 'order',


### PR DESCRIPTION
I find out that the example `CreateOrderRequest` has a field `number` which wrong type, `number` instead of `string`. So this MR will fix that.

Note: I test this by code as the image below

![image](https://user-images.githubusercontent.com/28798624/232320456-5f41c767-b000-42fa-991c-0a7243e0e829.png)

Please take a look anh @anhldbk 
IMHO if `amount` field goes along with `currency` or describes the default currency as VND will be better.